### PR TITLE
2 pr

### DIFF
--- a/core/class/wled.class.php
+++ b/core/class/wled.class.php
@@ -898,7 +898,11 @@ class wled extends eqLogic {
                 $this->checkAndUpdateCmd('power_state', 0);
             }
             $this->checkAndUpdateCmd('global_brightness_state', $result['bri']);
-            $this->checkAndUpdateCmd('preset_state', $result['ps']);
+            if ($result['pl'] == -1){
+                $this->checkAndUpdateCmd('preset_state', $result['ps']);
+            } else {
+                $this->checkAndUpdateCmd('preset_state', $result['pl']);
+            }
         }
         
         // Etat du segment


### PR DESCRIPTION
une playlist est constituée d'une succession de presets, cette modification permet d'éviter de faire un défilement des presets lorsqu'une playlist est sélectionnée

Et

ajout d'une commande refresh dans le segment 0
correction bug dans la gestion des segments
gestion des playlists dans la partie presets